### PR TITLE
Remove unnecessary id attribute

### DIFF
--- a/src/IframeComm.js
+++ b/src/IframeComm.js
@@ -69,7 +69,6 @@ class IframeComm extends Component {
         );
         return (
             <iframe
-                id="_iframe"
                 ref={el => {
                     this._frame = el;
                 }}


### PR DESCRIPTION
This should improve interoperability of this react component with the
rest of the DOM.

Maybe I missed something, but I believe the `id` attribute is not required for the iframe. In particular I think setting a fixed string as the ID attribute is bad because it might interfere with other DOM-components.