### PR TITLE
Migrate from React.PropTypes to prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@kadira/storybook-deployer": "^1.2.0",
+    "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "react-dom": "^15.4.2"
   },

--- a/src/IframeComm.js
+++ b/src/IframeComm.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 class IframeComm extends Component {
     constructor() {


### PR DESCRIPTION
`React.PropTypes` was deprecated as of [React v15.5.0](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes). This PR [migrates to the new `prop-types`](https://github.com/facebook/prop-types#migrating-from-reactproptypes) package.